### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/rogueserenity/datacrypt/security/code-scanning/2](https://github.com/rogueserenity/datacrypt/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will apply to all jobs that do not have their own `permissions` key. Since the `release` job already has specific permissions defined, it will remain unaffected. For the other jobs (`lint-commit`, `lint-go`, and `test-go`), we will set the permissions to `contents: read`, which is sufficient for their operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
